### PR TITLE
[#36] ウェブフォントちらつきの解消

### DIFF
--- a/src/scss/_fonts.scss
+++ b/src/scss/_fonts.scss
@@ -1,19 +1,24 @@
-// <style>
-// @import url('https://fonts.googleapis.com/css?family=Alex+Brush|Allura|Great+Vibes|Herr+Von+Muellerhoff|Italianno|Mr+De+Haviland|Parisienne|Petit+Formal+Script|Pinyon+Script|Tangerine:400,700&display=swap&subset=latin-ext');
-@import url('https://fonts.googleapis.com/css?family=Tangerine:400,700&display=swap&subset=latin-ext');
-// </style>
+// Tangerine
+/* latin */
+@font-face {
+    font-family: 'fbTangerine';
+    font-style: normal;
+    font-weight: 700;
+    font-display: block;
+    src: url(https://fonts.gstatic.com/s/tangerine/v17/Iurd6Y5j_oScZZow4VO5srNZi5FN.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
 
-// font-family: 'Great Vibes', cursive;
-// font-family: 'Tangerine', cursive;
-// font-family: 'Marck Script', cursive;
-// font-family: 'Playball', cursive;
-// font-family: 'Parisienne', cursive;
-// font-family: 'Italianno', cursive;
-// font-family: 'Allura', cursive;
+@mixin theme_fonts_en() {
+    font-family: 'fbTangerine', 'tangerine';
+}
 
+// Sawarabi Mincho japone
+@import url('https://fonts.googleapis.com/css?family=Sawarabi+Mincho&display=swap');
 
-//japone
-@import url('https://fonts.googleapis.com/css?family=Noto+Serif+JP:200|Sawarabi+Mincho&display=swap');
+$webMinchoFont: 'Sawarabi Mincho';
+$localMinchoFont: '游明朝', 'YuMincho', 'Hiragino Mincho ProN W3', 'ヒラギノ明朝 ProN W3', 'Hiragino Mincho ProN', 'HG明朝E', 'ＭＳ Ｐ明朝', 'ＭＳ 明朝', 'serif';
 
-//font-family: 'Sawarabi Mincho', sans-serif;
-//font-family: 'Noto Serif JP', serif;
+@mixin theme_fonts() {
+    font-family: join($webMinchoFont, $localMinchoFont)
+}

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -1,6 +1,7 @@
 @use "my_mixins" as mix;
 @use "sass:math";
-@import "my_variables", "my_mixins", "my_common_style", "fonts";
+@use "fonts" as font;
+@import "my_variables", "my_mixins", "my_common_style";
 
 $imagesPath: "../images/";
 @function imgUrl($fileName) {
@@ -212,9 +213,7 @@ a {
 }
 
 li, p, dd, dt, h3, h4 {
-    font-family: 'Sawarabi Mincho', sans-serif;
-    // font-weight: 200;
-    //font-family: 'Noto Serif JP', serif;
+    @include font.theme_fonts;
 }
 
 p{
@@ -503,18 +502,10 @@ dd {
 
 
 
-@mixin fonts() {
-    font-family: 'Sawarabi Mincho', sans-serif;
-}
-@mixin fonts_eng() {
-    font-family: 'Tangerine', cursive;
-}
-
-
+// --- top page button ---
 .ff_theme{
-    @include fonts;
+    @include font.theme_fonts;
 }
-
 
 .button {
   border-radius: 1px;
@@ -525,7 +516,7 @@ dd {
       color: map-get($clrMap, 'text');
       font-size: 2rem;
       display: block;
-      @include fonts_eng;
+      @include font.theme_fonts_en;
       padding-bottom: 0.3rem;
     }
 
@@ -845,7 +836,7 @@ $imgSizeKurageY: 200px;
             }
             &::after {
                 padding: 4px;
-                font-family: 'Tangerine', cursive;
+                @include font.theme_fonts_en;
                 font-size: 2.2rem;
                 line-height: 1;
                 text-align: center;
@@ -880,7 +871,7 @@ $imgSizeKurageY: 200px;
     letter-spacing: 0.5rem;
     font-weight: 1;
     // font-family: 'Great Vibes', cursive;
-    // font-family: 'Tangerine', cursive;
+    // @include font.theme_fonts_en;
     // font-family: 'Parisienne', cursive;
     // font-family: 'Italianno', cursive;
     // font-family: 'Allura', cursive;
@@ -889,7 +880,7 @@ $imgSizeKurageY: 200px;
     // font-family: 'Petit Formal Script', cursive;
     // font-family: 'Herr Von Muellerhoff', cursive;
     // font-family: 'Mr De Haviland', cursive;
-    font-family: 'Sawarabi Mincho', sans-serif;
+    @include font.theme_fonts;
     padding-left: 0;
     padding-right: 0;
     & span{
@@ -1119,7 +1110,7 @@ $imgSizeKurageY: 200px;
         top: math.div($mainVisualHeight, 2);
         left: 50%;
         transform:translateX(-50%) translateY(-50%);
-        font-family: 'Tangerine', cursive;
+        @include font.theme_fonts_en;
         font-size: 7rem;
         font-weight: 1000;
         color: #FFF;
@@ -1248,7 +1239,7 @@ $catchCircleDiameter: 100px;
         letter-spacing: 0.2rem;
         font-weight: 1;
         // font-family: 'Great Vibes', cursive;
-        // font-family: 'Tangerine', cursive;
+        // @include font.theme_fonts_en;
         // font-family: 'Parisienne', cursive;
         // font-family: 'Italianno', cursive;
         // font-family: 'Allura', cursive;
@@ -1257,7 +1248,7 @@ $catchCircleDiameter: 100px;
         // font-family: 'Petit Formal Script', cursive;
         // font-family: 'Herr Von Muellerhoff', cursive;
         // font-family: 'Mr De Haviland', cursive;
-        font-family: 'Sawarabi Mincho', sans-serif;
+        @include font.theme_fonts;
         padding-left: 0;
         padding-right: 0;
         transform: scale(0.8, 1);
@@ -1614,7 +1605,7 @@ input[type="submit"] {
     }
 
     &_logo{
-        font-family: 'Tangerine', cursive;
+        @include font.theme_fonts_en;
         font-size: 4rem;
         font-weight: 1000;
         color: #FFF;


### PR DESCRIPTION
close #32

# やったこと

FOUT の抑制。

- ファーストビューの店名のフォントはデザイン目的でそのまま表示したいため`font-display: block;`を指定。
- その他フォントは、`font-display: swap;`で、フォントダウンロード後入れ替えとし、コンテンツの表示を優先します。
  - swap前にはローカル明朝フォントを代替として指定することで違和感を抑えました。
