### PR TITLE
[#24] レイアウト調整

### DIFF
--- a/dist/course.html
+++ b/dist/course.html
@@ -21,7 +21,7 @@
     <h1 class="mx-0 my-0 ta-c main_vis_text main_vis_text_second">Spa<span>zz</span>atura</h1>
   </div>
 
-  <div class="container">
+  <div class="container-expand">
     <nav class="global_menu full-width sticky_nav_wrap" id="stickyNav">
       <ul class="mx-auto my-0 d-n-ls-l">
         <li id="gnav1" class="gnav_anim"><a class="addClsActiveLink" href="index.html">ホーム</a></li>

--- a/dist/menu.html
+++ b/dist/menu.html
@@ -21,7 +21,7 @@
     <h1 class="mx-0 my-0 ta-c main_vis_text main_vis_text_second">Spa<span>zz</span>atura</h1>
   </div>
 
-  <div class="container">
+  <div class="container-expand">
     <nav class="global_menu full-width sticky_nav_wrap" id="stickyNav">
       <ul class="mx-auto my-0">
         <li id="gnav1" class="gnav_anim"><a class="addClsActiveLink" href="index.html">ホーム</a></li>
@@ -125,7 +125,7 @@
       </div>
 
       <h3 class="w-100per home_h2_style hr ta-c">ドングリ</h3>
-      <article class="container menu_table d_flex_row my-3 mx-auto px-0">
+      <article class="menu_table d_flex_row my-3 mx-auto px-0">
         <h3 class="w-50per home_h2_style hr-fade ta-c mb-1">白ワイン</h3>
         <dl>
           <dt>プレン・シュッド　エステザルグ共同組合</dt>

--- a/dist/message.html
+++ b/dist/message.html
@@ -21,7 +21,7 @@
     <h1 class="mx-0 my-0 ta-c main_vis_text main_vis_text_second">Spa<span>zz</span>atura</h1>
   </div>
 
-  <div class="container">
+  <div class="container-expand">
     <nav class="global_menu full-width sticky_nav_wrap" id="stickyNav">
       <ul class="mx-auto my-0 d-n-ls-l">
         <li id="gnav1" class="gnav_anim"><a class="addClsActiveLink" href="index.html">ホーム</a></li>
@@ -43,36 +43,40 @@
     <section class="mt-8 mb-5">
       <h2 class="w-100per mb-6 home_h2_style hr"><span>MESSAGE</span></h2>
 
-      <div class="message_wrap ta-c px-0 mx-2 mb-8 mx-auto">
+      <div class="message_wrap ta-c px-0 mb-8 mx-auto">
         <div class="message_text">
-          <h3 class="message_title pt-1 d-inline-block">MESSAGE FROM CHEF</h3>
-          <h4 class="home_content_text ta-c mb-0">一期一会のお料理を</h4>
-          <p class="home_content_text lh-2 mt-0 pt-1">
-            料理人は一つの職業ですが、<br>
-            私にとっては生き方そのものです。<br>
-            そういったことを<br>
-            伝えることができれば幸せです。<br>
-            <br>
-            <span>suzuki toro</span><br>
-            スズキ タロウ<br>
-          </p>
+          <div class="f-center-column pt-2">
+            <h3 class="message_title">MESSAGE FROM CHEF</h3>
+            <h4 class="home_content_text ta-c mb-0">一期一会のお料理を</h4>
+            <p class="home_content_text lh-2 mt-0 pt-1">
+              料理人は一つの職業ですが、<br>
+              私にとっては生き方そのものです。<br>
+              そういったことを<br>
+              伝えることができれば幸せです。<br>
+              <br>
+              <span>suzuki toro</span><br>
+              スズキ タロウ<br>
+            </p>
+          </div>
         </div>
         <img class="message_image" src="./images/chef.jpg" alt="">
       </div>
 
-      <div class="message_wrap ta-c px-0 mx-2 mb-8 mx-auto">
+      <div class="message_wrap ta-c px-0 mb-8 mx-auto">
         <div class="message_text">
-          <h3 class="message_title pt-1 d-inline-block">MESSAGE FROM PATISSIERE</h3>
-          <h4 class="home_content_text ta-c mb-0">忘れない味と時間をご提供いたします</h4>
-          <p class="home_content_text lh-2 mt-0 pt-1">
-            上品な味を作り出すため、<br>
-            選び抜いた食材を使い、<br>
-            食材本来の味を活かしています。<br>
-            <br>
-            <span>suzuki jiroko</span><br>
-            スズキ ジロコ<br>
-            <br>
-          </p>
+          <div class="f-center-column">
+            <h3 class="message_title pt-1">MESSAGE FROM PATISSIERE</h3>
+            <h4 class="home_content_text ta-c mb-0">忘れない味と時間をご提供いたします</h4>
+            <p class="home_content_text lh-2 mt-0 pt-1">
+              上品な味を作り出すため、<br>
+              選び抜いた食材を使い、<br>
+              食材本来の味を活かしています。<br>
+              <br>
+              <span>suzuki jiroko</span><br>
+              スズキ ジロコ<br>
+              <br>
+            </p>
+          </div>
         </div>
         <img class="message_image" src="./images/patissiere.jpg" alt="">
       </div>

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -23,7 +23,7 @@ $sideTabWidth: 10rem;
 $sideTabClr: #444;
 
 $containerWidth: 1200px;
-$containerExpandWidth: 1600px;
+$containerExpandWidth: 1400px;
 $clrMain:#432;
 $clrMainLight: lighten($clrMain, 5%);
 $clrSub1:#fff4ea;
@@ -239,6 +239,10 @@ dd {
     display: block;
 }
 
+.d-flex {
+    display: flex;
+}
+
 .d-inline{
     display: inline;
 }
@@ -426,6 +430,14 @@ dd {
     }
 }
 
+// --- layouts ---
+.f-center-column {
+    display:flex;
+    height: 100%;
+    flex-flow: column;
+    justify-content: center;
+    align-items: center;
+}
 
 // ============= js用パーツ ===============
 .nav_active_page{
@@ -1003,12 +1015,21 @@ $imgSizeKurageY: 200px;
     & dl {
         display: flex;
         flex-wrap: wrap;
-        // border: 1px solid #ccc;
         border-top: none;
         width: 100%;
         background-color: map-get($clrMap, 'sub3');
         color: map-get($clrMap, 'sub1');
         // box-shadow: 0px 2px 2px rgba(0, 0, 0, .4);
+
+        &:nth-of-type(n+1){
+            border-top: 1px solid #ccc;
+        }
+
+        @include mix.md-l {
+            &:nth-of-type(1){
+                border-top: 1px solid #ccc;
+            }
+        }
     }
 
     & dt {
@@ -1021,14 +1042,11 @@ $imgSizeKurageY: 200px;
         };
         justify-content: start;
         align-items: center;
+        min-width: 2rem;
 
         &:nth-of-type(even){
             padding-left: 3rem;
         }
-
-        // &:nth-of-type(2){
-        //     border-bottom: 1px solid #ccc;
-        // }
     }
 
     & dd {
@@ -1048,7 +1066,6 @@ $imgSizeKurageY: 200px;
         &:nth-of-type(odd){
             padding-right: 3rem;
         }
-
     }
     & dt, & dd{
         // height: 3.6rem;
@@ -1069,8 +1086,10 @@ $imgSizeKurageY: 200px;
             &:nth-of-type(2n-1){
                 background-color: map-get($clrMap, 'hr');
             }
+            &:empty {
+                display: none;
+            }
         }
-
     }
 }
 

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -23,6 +23,7 @@ $sideTabWidth: 10rem;
 $sideTabClr: #444;
 
 $containerWidth: 1200px;
+$containerExpandWidth: 1600px;
 $clrMain:#432;
 $clrMainLight: lighten($clrMain, 5%);
 $clrSub1:#fff4ea;
@@ -316,16 +317,22 @@ dd {
     margin: 0 auto;
 }
 
-// .h-100{
-    // height: 100%;
-    //移動すべき記述
-    // text-align: center;
-    // line-height: 5;
-// }
+.full-width {
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+}
 
 .container{
     margin: 0 auto;
     max-width: $containerWidth;
+    width: 100%;
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+.container-expand{
+    margin: 0 auto;
+    max-width: $containerExpandWidth;
     width: 100%;
     padding-left: 15px;
     padding-right: 15px;
@@ -1211,74 +1218,6 @@ $catchCircleDiameter: 100px;
         & span{
             color: $carmine;
         }
-}
-
-// ============= message ===============
-.message {
-
-    &_wrap {
-        outline: 1px solid white;
-        outline-offset: -6px;
-        width: 100%;
-        max-width: 1138px;
-        max-height: 450px;
-        min-height: 410px;
-        height: 38vw;
-        box-sizing: border-box;
-        // font-size: 0;
-        overflow: hidden;
-
-        @include mix.lg-l {
-            // height: 800px;
-            max-height: 800px;
-            height: auto;
-        }
-    }
-
-    &_title {
-        letter-spacing: 0.2rem;
-        font-weight: 1;
-        // font-family: 'Great Vibes', cursive;
-        // @include font.theme_fonts_en;
-        // font-family: 'Parisienne', cursive;
-        // font-family: 'Italianno', cursive;
-        // font-family: 'Allura', cursive;
-        // font-family: 'Pinyon Script', cursive;
-        // font-family: 'Alex Brush', cursive;
-        // font-family: 'Petit Formal Script', cursive;
-        // font-family: 'Herr Von Muellerhoff', cursive;
-        // font-family: 'Mr De Haviland', cursive;
-        @include font.theme_fonts;
-        padding-left: 0;
-        padding-right: 0;
-        transform: scale(0.8, 1);
-        // width: 150%;
-    }
-
-    &_text {
-        margin: 0;
-        padding: 1rem;
-        display: inline-block;
-        background-color: map-get($clrMap, 'main');
-        vertical-align: top;
-        width: 35%;
-        height: 100%;
-        @include mix.lg-l {
-            width: 100%;
-            // height: 30%;
-        }
-    }
-
-    &_image {
-        display: inline-block;
-        max-width: 800px;
-        width: 65%;
-        @include mix.lg-l {
-            width: 100%;
-            max-width: 100%;
-        }
-    }
-
 }
 
 // ============= section ===============

--- a/src/scss/spazzatura.scss
+++ b/src/scss/spazzatura.scss
@@ -1,3 +1,4 @@
+@use "fonts" as font;
 @use "sass:math";
 $mainVisualHeight: 480px;
 $globalNavHeight: 80px;
@@ -99,9 +100,17 @@ a {
     height: 100%;
 }
 
-.full-width {
+.full_width_access {
     margin-left: calc(-50vw + 50%);
     margin-right: calc(-50vw + 50%);
+
+    padding-left: 2rem;
+    padding-right: 2rem;
+
+    @include mix.md-l {
+        padding-left: 0rem;
+        padding-right: 0rem;
+    }
 }
 
 .container{
@@ -613,7 +622,6 @@ input[type="submit"] {
     }
 }
 
-
 // ============= message ===============
 .message {
 
@@ -622,7 +630,7 @@ input[type="submit"] {
         outline-offset: -6px;
         width: 100%;
         max-width: 1138px;
-        max-height: 450px;
+        max-height: 600px;
         min-height: 410px;
         height: 38vw;
         box-sizing: border-box;
@@ -630,43 +638,39 @@ input[type="submit"] {
         overflow: hidden;
 
         @include mix.lg-l {
-            // height: 800px;
-            max-height: 800px;
+            max-height: 900px;
             height: auto;
+        }
+
+        // inline-box 回り込み対策
+        letter-spacing: -1em;
+        * {
+            letter-spacing: normal;
         }
     }
 
     &_title {
         letter-spacing: 0.2rem;
         font-weight: 1;
-        // font-family: 'Great Vibes', cursive;
-        // @include font.theme_fonts_en;
-        // font-family: 'Parisienne', cursive;
-        // font-family: 'Italianno', cursive;
-        // font-family: 'Allura', cursive;
-        // font-family: 'Pinyon Script', cursive;
-        // font-family: 'Alex Brush', cursive;
-        // font-family: 'Petit Formal Script', cursive;
-        // font-family: 'Herr Von Muellerhoff', cursive;
-        // font-family: 'Mr De Haviland', cursive;
         @include font.theme_fonts;
         padding-left: 0;
         padding-right: 0;
         transform: scale(0.8, 1);
-        // width: 150%;
     }
 
     &_text {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         margin: 0;
         padding: 1rem;
         display: inline-block;
-        background-color: map-get($clrMap, 'main');
+        background-color: map-get(cmn.$clrMap, 'main');
         vertical-align: top;
         width: 35%;
         height: 100%;
         @include mix.lg-l {
             width: 100%;
-            // height: 30%;
         }
     }
 
@@ -674,9 +678,11 @@ input[type="submit"] {
         display: inline-block;
         max-width: 800px;
         width: 65%;
+        height:100%;
+        object-fit: cover;
         @include mix.lg-l {
-            width: 100%;
-            max-width: 100%;
+            min-width: 100%;
+            min-height: 300px;
         }
     }
 

--- a/src/scss/spazzatura.scss
+++ b/src/scss/spazzatura.scss
@@ -97,9 +97,11 @@ a {
 
 .h-100{
     height: 100%;
-    //移動すべき記述
-    // text-align: center;
-    // line-height: 5;
+}
+
+.full-width {
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
 }
 
 .container{
@@ -612,6 +614,73 @@ input[type="submit"] {
 }
 
 
+// ============= message ===============
+.message {
+
+    &_wrap {
+        outline: 1px solid white;
+        outline-offset: -6px;
+        width: 100%;
+        max-width: 1138px;
+        max-height: 450px;
+        min-height: 410px;
+        height: 38vw;
+        box-sizing: border-box;
+        // font-size: 0;
+        overflow: hidden;
+
+        @include mix.lg-l {
+            // height: 800px;
+            max-height: 800px;
+            height: auto;
+        }
+    }
+
+    &_title {
+        letter-spacing: 0.2rem;
+        font-weight: 1;
+        // font-family: 'Great Vibes', cursive;
+        // @include font.theme_fonts_en;
+        // font-family: 'Parisienne', cursive;
+        // font-family: 'Italianno', cursive;
+        // font-family: 'Allura', cursive;
+        // font-family: 'Pinyon Script', cursive;
+        // font-family: 'Alex Brush', cursive;
+        // font-family: 'Petit Formal Script', cursive;
+        // font-family: 'Herr Von Muellerhoff', cursive;
+        // font-family: 'Mr De Haviland', cursive;
+        @include font.theme_fonts;
+        padding-left: 0;
+        padding-right: 0;
+        transform: scale(0.8, 1);
+        // width: 150%;
+    }
+
+    &_text {
+        margin: 0;
+        padding: 1rem;
+        display: inline-block;
+        background-color: map-get($clrMap, 'main');
+        vertical-align: top;
+        width: 35%;
+        height: 100%;
+        @include mix.lg-l {
+            width: 100%;
+            // height: 30%;
+        }
+    }
+
+    &_image {
+        display: inline-block;
+        max-width: 800px;
+        width: 65%;
+        @include mix.lg-l {
+            width: 100%;
+            max-width: 100%;
+        }
+    }
+
+}
 
 // ============= footer ===============
 


### PR DESCRIPTION
close #24

- [#24] message class の移動
- [#24] レイアウト調整

- message.html
  - ページの写真が画面解像度によっては要素の大きさより小さく表示されていたため修正
- ページ全体のコンテナの大きさを1400px以上に
- menu.html
  - メニューテーブルがスマホ表示のときにカラムが1になる。そのときにメニューが奇数だと空欄メニューが表示されていたので修正
