### PR TITLE
[#53] 本番環境と開発環境で自動で切り替わる cofig js を作成

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,9 +9,8 @@ module.exports = {
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "ecmaVersion": 2018
   },
   "rules": {
     "semi": [2, "always"]
   }
-}
+};

--- a/conf/development.js
+++ b/conf/development.js
@@ -1,0 +1,8 @@
+export default {
+  /**
+   * for GitHub Pages
+   * @type {Boolean} - domain と 'top page' の間にリポジトリ名を持つURLか
+   * e.g. https://[domain]/URL_PREFIX/toppage/path?=
+   */
+   hasUrlPathPrefix : false
+};

--- a/conf/production.js
+++ b/conf/production.js
@@ -1,0 +1,8 @@
+export default {
+  /**
+   * for GitHub Pages
+   * @type {Boolean} - domain と 'top page' の間にリポジトリ名を持つURLか
+   * e.g. https://[domain]/URL_PREFIX/toppage/path?=
+   */
+   hasUrlPathPrefix : true
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
 "use strict";
 
+import appConf from 'appConf';
+console.log(appConf.hasUrlPathPrefix);
+
 // debug console
 console.print = false;
 console.dev = (...args) => { if (console.print) console.log(...args); };
@@ -107,7 +110,7 @@ const throttle = (callback, interval = 200, ...args) => {
 const addClassActivePageLink = () => {
   const className = 'nav_active_page';
   for (const el of document.querySelectorAll('#gnav a')){
-    console.dev(pageCategory().replace('/',''), el.getAttribute('href').replace('/',''));
+    console.dev(pageCategory(), el.getAttribute('href'));
     if (pageCategory().replace('/','') === el.getAttribute('href').replace('/','')){
       addClass(el, className);
       return;
@@ -182,7 +185,7 @@ const doWhenIntersect = entries => {
 const startFadeInAnim = el => {
   /** @type {Number} ms. CSSアニメーションの長さと合わせる */
   const animationTime = 300;
-  /** @type {String} animation class name */
+  /** @type {string} animation class name */
   const animationClass = 'fadeInAnim';
   if (! el.classList.contains(animationClass)){
     addClass(el, animationClass);
@@ -193,17 +196,17 @@ const startFadeInAnim = el => {
 // css 関連ヘルパ
 /**
  * @param {HTMLElement} el
- * @param {String} className
+ * @param {string} className
  */
 const addClass = (el, className) => el.classList.add(className);
 /**
  * @param {HTMLElement} el
- * @param {String} className
+ * @param {string} className
  */
 const rmClass = (el, className) => el.classList.remove(className);
 /**
  * @param {HTMLElement} el
- * @param {String} styleName
+ * @param {string} styleName
  */
 const getCssValue = (el, styleName) => window.getComputedStyle(el).styles.getPropertyValue(styleName);
 
@@ -217,9 +220,23 @@ const getCurrentY = () => window.scrollY;
  * @return {string}
  */
 const pageCategory = () => {
-  const current = location.pathname.split()[0];
+  console.dev(spazzatura.homePathPos);
+  const current = solvePathPrefix(appConf.hasUrlPathPrefix);
   if (current === '' || current === '/'){
     return spazzatura.home;
   }
   return current;
 };
+
+/**
+ * false であれあばドメイン直下、true であればその次のパス文字列を返します。
+ * @param {boolean} prefix [false]
+ * @return {string}
+ */
+const solvePathPrefix = (prefix = false) => {
+  if (prefix){
+    return location.pathname.split('/')[2];
+  }
+  return location.pathname.split('/')[1];
+};
+

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -21,6 +21,9 @@ module.exports = merge(common, {
     watchFiles: ['src/**/*', 'dist/**/*html'],
   },
   resolve: {
-    extensions: ['.js', '.ts', '.tsx']
+    extensions: ['.js', '.ts', '.tsx'],
+    alias: {
+      appConf$: path.resolve(__dirname, 'conf/development.js'),
+    },
   },
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -2,10 +2,17 @@ const path = require('path');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
+
 /** @type {import('webpack').Configuration} */
 module.exports = merge(common, {
   mode: 'production',
+
   output: {
     publicPath: "auto"
+  },
+  resolve: {
+    alias: {
+      appConf$: path.resolve(__dirname, 'conf/production.js'),
+    },
   },
 });


### PR DESCRIPTION
solve #53

# やったこと

- `webpack`の`dev`か`prod`で自動的に参照が自動で切り替わるように以下設定ファイルを追加しました
  - [conf/development.js](https://github.com/y-web21/Spazzatura/pull/60/files#diff-d6a65aab549207168d876062e92633ecf266c98cc47d26da8caec028f93ad4b5)
  - [conf/prroduction.js](https://github.com/y-web21/Spazzatura/pull/60/files#diff-1e386c30c5c591935d4e7d8d41e129e20bfc20698f3fd564e133b14055a289d6)
- 後は、読み込めるように周囲のファイルを調整 

