### PR TITLE
[#62] h1レイアウト修正

### DIFF
--- a/src/scss/spazzatura.scss
+++ b/src/scss/spazzatura.scss
@@ -209,7 +209,7 @@ $imgSizeKurageY: 200px;
     &_text{
 
         position: absolute;
-        top: math.div($mainVisualHeight, 2);
+        top: 25vh;
         left: 50%;
         transform:translateX(-50%) translateY(-50%);
         @include font.theme_fonts_en;


### PR DESCRIPTION
`scss`の除算を`math.div()`に修正する過程で必要がない場所まで修正していた