### PR TITLE
[#23] node version を18に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "webpack-dev-server": "^4.11.1"
       },
       "engines": {
-        "node": "16.14.x",
-        "npm": "8.5.x"
+        "node": "18.x"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "bswatch": "browser-sync start --config bs-config.js; webpack --config webpack.dev.js --mode development"
   },
   "engines": {
-    "node": "16.14.x",
-    "npm": "8.5.x"
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
close #23 

# やったこと

- `node 16.14.x`の指定から現行LTSの`18.x`に変更
  - マイナーまで絞る必要性がないため  